### PR TITLE
Add simple narration generator

### DIFF
--- a/generate_narration.py
+++ b/generate_narration.py
@@ -1,0 +1,30 @@
+"""Python script to generate narration for script scenes"""
+
+import textwrap
+import sys
+
+
+def generate_narration(scene_description: str) -> str:
+    """Generate a simple narration line based on a scene description."""
+    return textwrap.fill(
+        f"Nessa cena, {scene_description.strip()}. O que acontece a seguir promete envolver o espectador.",
+        width=70,
+    )
+
+
+def main(scene_file: str) -> None:
+    with open(scene_file, 'r', encoding='utf-8') as f:
+        scenes = [line.strip() for line in f if line.strip()]
+
+    for idx, scene in enumerate(scenes, start=1):
+        print(f"Cena {idx}:")
+        print(generate_narration(scene))
+        print()
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Uso: python generate_narration.py <arquivo_de_cenas.txt>")
+        sys.exit(1)
+
+    main(sys.argv[1])

--- a/scenes.txt
+++ b/scenes.txt
@@ -1,0 +1,3 @@
+Acordamos de manhã e nos preparamos para o dia de trabalho na fazenda.
+Seguimos para o campo para verificar o estado das plantações.
+Finalizamos o dia com uma reunião para planejar as próximas etapas.


### PR DESCRIPTION
## Summary
- add a Python script `generate_narration.py` for generating scene narrations
- include example `scenes.txt` with three sample scenes

## Testing
- `python3 generate_narration.py scenes.txt`

------
https://chatgpt.com/codex/tasks/task_e_685fd829f5388322a8ce93c4c4167e73