### PR TITLE
Add script to convert images to URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
 # IA-Agro
+
+Este repositório inclui um pequeno script em Python para transformar imagens locais em URLs no formato Data URL.
+
+## Utilização
+
+1. Coloque suas imagens em um diretório (por padrão `images/`).
+2. Execute o script `convert_images_to_urls.py`:
+
+```bash
+python3 convert_images_to_urls.py images -o urls.json
+```
+
+O script irá gerar o arquivo `urls.json` contendo um mapeamento entre nomes de arquivos e suas URLs em formato Data URL.

--- a/convert_images_to_urls.py
+++ b/convert_images_to_urls.py
@@ -1,0 +1,37 @@
+import os
+import base64
+import mimetypes
+import json
+import argparse
+
+def image_to_data_url(path: str) -> str:
+    """Encode uma imagem como uma Data URL."""
+    mime_type, _ = mimetypes.guess_type(path)
+    if mime_type is None:
+        mime_type = 'application/octet-stream'
+    with open(path, 'rb') as f:
+        encoded = base64.b64encode(f.read()).decode('ascii')
+    return f'data:{mime_type};base64,{encoded}'
+
+def convert_directory(directory: str) -> dict:
+    """Converte todas as imagens de um diretório em Data URLs."""
+    urls = {}
+    for filename in os.listdir(directory):
+        filepath = os.path.join(directory, filename)
+        if os.path.isfile(filepath):
+            urls[filename] = image_to_data_url(filepath)
+    return urls
+
+def main():
+    parser = argparse.ArgumentParser(description="Transforma todas as imagens de um diretório em URLs (formato Data URL).")
+    parser.add_argument('directory', nargs='?', default='images', help='Diretório contendo as imagens.')
+    parser.add_argument('-o', '--output', default='image_urls.json', help='Arquivo JSON para salvar as URLs geradas.')
+    args = parser.parse_args()
+
+    urls = convert_directory(args.directory)
+    with open(args.output, 'w') as f:
+        json.dump(urls, f, indent=2, ensure_ascii=False)
+    print(f'Salvo {len(urls)} URLs em {args.output}')
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- create `convert_images_to_urls.py` to encode images as Data URLs
- expand README with usage instructions for the script

## Testing
- `python3 -m py_compile convert_images_to_urls.py`
- `pytest -q`
- `python3 convert_images_to_urls.py --help`


------
https://chatgpt.com/codex/tasks/task_e_685fd8882c908322ae9dd271a399645a