### PR TITLE
Add simple Jupyter video viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
 # IA-Agro
+
+This repository contains utilities for working with video scenes in JupyterLab.
+
+## Scene Viewer
+
+`scene_viewer.py` provides a simple widget-based player to navigate and play
+video files from a `scenes/` directory.
+
+### Usage
+
+1. Place your video files (e.g., `.mp4`) inside a folder named `scenes` in the
+   repository root.
+2. In a JupyterLab notebook, import and launch the player:
+   ```python
+   import scene_viewer
+   scene_viewer.scene_player()
+   ```
+3. Select a scene from the dropdown to play the video inline.
+
+The first video found in the directory will be displayed automatically.

--- a/scene_viewer.py
+++ b/scene_viewer.py
@@ -1,0 +1,37 @@
+import os
+from IPython.display import Video, display
+import ipywidgets as widgets
+
+
+def list_scene_files(directory='scenes'):
+    """Return a list of video files in the specified directory."""
+    supported = ('.mp4', '.mov', '.avi', '.mkv')
+    return [f for f in os.listdir(directory) if f.lower().endswith(supported)]
+
+
+def show_video(file_path):
+    """Display a video file in JupyterLab."""
+    display(Video(file_path))
+
+
+def scene_player(directory='scenes'):
+    """Create a dropdown-based video player for scenes inside a directory."""
+    files = list_scene_files(directory)
+    if not files:
+        raise FileNotFoundError(f'No video files found in {directory}')
+
+    dropdown = widgets.Dropdown(options=files, description='Scene:')
+
+    def on_change(change):
+        if change['type'] == 'change' and change['name'] == 'value':
+            display(Video(os.path.join(directory, change['new'])))
+
+    dropdown.observe(on_change)
+    display(dropdown)
+
+    # Show first video initially
+    show_video(os.path.join(directory, files[0]))
+
+
+if __name__ == '__main__':
+    scene_player()


### PR DESCRIPTION
## Summary
- add `scene_viewer.py` for playing scene videos in JupyterLab
- update README with usage instructions

## Testing
- `python -m py_compile scene_viewer.py`

------
https://chatgpt.com/codex/tasks/task_e_685fd8c88ee88322af67c82479287ba4